### PR TITLE
Add robots.txt to improve SEO and prevent scraping

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,42 @@
+# robots.txt for rioto3.com
+
+User-agent: *
+Disallow: /admin/
+Disallow: /api/
+Disallow: /private/
+Disallow: /draft/
+Allow: /
+
+# Disallow crawling of archives
+Disallow: /*?
+
+# Limit specific bots that tend to overload sites
+
+# GPTBot
+User-agent: GPTBot
+Disallow: /
+
+# CommonCrawl Bot
+User-agent: CCBot
+Disallow: /
+
+# AI data mining bots
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+# Rate limit Google
+User-agent: Googlebot
+Crawl-delay: 1
+
+# Rate limit Bing
+User-agent: Bingbot
+Crawl-delay: 1
+
+# Sitemap location
+Sitemap: https://rioto3.com/sitemap-index.xml


### PR DESCRIPTION
## 概要
スクレイピングと不要なインデックスを防ぎつつ、正規の検索エンジンには適切なサイト情報を提供するための robots.txt を追加しました。

## 変更内容
- 新しい `public/robots.txt` ファイルを追加
- 主な内容:
  - 管理者用ページや API へのアクセスを禁止
  - GPTBot、CCBot などの AI クローラーをブロック
  - Googlebot や Bingbot などの検索エンジンには適切なクロール遅延を設定
  - サイトマップの場所を指定

## 留意点
- サイトマップの URL（`https://rioto3.com/sitemap-index.xml`）は仮の設定です。実際のドメインに合わせて変更してください。
- 必要に応じて、より詳細なディレクトリやパスのルールを追加できます。