### PR TITLE
自動サイトマップ生成機能の追加

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,11 +1,31 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
-
 import tailwindcss from '@tailwindcss/vite';
+import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://rioto3.com', // サイトのURLを指定（本番用に変更が必要）
   vite: {
     plugins: [tailwindcss()]
-  }
+  },
+  integrations: [
+    sitemap({
+      // サイトマップ設定オプション
+      filter: (page) => !page.includes('/private/') && !page.includes('/draft/'), // 特定のパスを除外
+      changefreq: 'weekly', // デフォルトの頻度
+      lastmod: new Date(), // 最終更新日
+      serialize(item) {
+        // 記事ページには異なる変更頻度を設定
+        if (item.url.includes('/articles/')) {
+          return {
+            ...item,
+            changefreq: 'monthly', 
+            priority: 0.7
+          };
+        }
+        return item;
+      },
+    }),
+  ],
 });


### PR DESCRIPTION
## 概要
Astroのサイトマップ統合を有効にして、自動的にサイトマップを生成するようにしました。これにより、SEO改善と検索エンジンによるサイトインデックスが最適化されます。

## 変更内容
- `astro.config.mjs` ファイルを更新
- `@astrojs/sitemap` 統合を有効化

## サイトマップの主な設定内容
- デフォルトでは週次の変更頻度を設定
- 記事ページには月次の変更頻度と0.7の優先度を設定
- `/private/` および `/draft/` を含むURLは除外

## 注意点
- `site` オプションには現在 `https://rioto3.com` を指定していますが、本番環境用のドメインに合わせて変更してください
- サイトマップは自動的に `/sitemap-index.xml` に生成されます
- ビルド時に自動生成されるため、手動でのメンテナンスは不要

これにより、`robots.txt` で指定したサイトマップURLと連携して、検索エンジンへの最適なインデックスが可能になります。