### PR TITLE
(Claude) ヘッダーにロゴ画像を追加

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -47,6 +47,11 @@ const {
       <div class="max-w-3xl mx-auto px-3 sm:px-4">
         <nav class="flex flex-col sm:flex-row sm:justify-between sm:items-center">
           <div class="flex justify-between items-center">
+            <img 
+              src="/favicons/icon-128x128.png" 
+              alt="Rioto3 Logo" 
+              class="w-10 h-10 mr-3 rounded-full"
+            />
             <a href="/" class="text-lg sm:text-xl font-bold">Rioto3</a>
             <button id="menu-toggle" class="sm:hidden p-1">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## 変更内容
- ヘッダーにロゴ画像を追加
- `/favicons/icon-128x128.png` を使用
- 画像にスタイリングを適用（丸型、サイズ指定）

## 変更理由
- ヘッダーのビジュアル改善
- ブランディングの強化
- サイトの視覚的一貫性の向上

## チェックリスト
- [x] ロゴ画像の追加
- [x] レスポンシブデザインの確認
- [ ] モバイル表示の検証
- [ ] デザインの最終確認

追加の調整が必要な場合は、コメントでお知らせください。