### PR TITLE
Add published-rioto3jp flag to support independent publishing

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,9 +53,9 @@ const articleEntries = await Promise.all(
   })
 );
 
-// 公開済みの記事のみフィルタリング
+// 個人サイト用に公開された記事のみフィルタリング
 const publishedArticles = articleEntries
-  .filter(article => article.frontmatter.published !== false)
+  .filter(article => article.frontmatter['published-rioto3jp'] === true)
   .sort((a, b) => 
     new Date(b.frontmatter.date || 0) - new Date(a.frontmatter.date || 0)
   )

--- a/src/utils/contentFetcher.ts
+++ b/src/utils/contentFetcher.ts
@@ -8,6 +8,8 @@ export interface ArticleContent {
   frontmatter: {
     title: string;
     date: string;
+    published?: boolean;
+    'published-rioto3jp'?: boolean;
     [key: string]: any;
   };
 }
@@ -45,6 +47,8 @@ export async function fetchLocalMarkdownFiles(
       frontmatter: {
         title: data.title || path.basename(file, '.md'),
         date: data.date || new Date().toISOString(),
+        published: data.published || false,
+        'published-rioto3jp': data['published-rioto3jp'] || false,
         ...data
       }
     };


### PR DESCRIPTION
## 変更内容
- `ArticleContent`インターフェースに`published-rioto3jp`フラグを追加
- Zennと個人サイトで独立した公開制御を可能にする

## 影響
- 既存の記事は`published-rioto3jp: false`としてデフォルト処理
- 記事表示コンポーネントで新しいフィルタリングが可能

### チェックポイント
- インターフェースの変更
- デフォルト値の設定
- フィルタリングロジックの更新が必要

Closes #31