### PR TITLE
Add published-rioto3jp flag and update filtering logic

### DIFF
--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -53,8 +53,13 @@ export async function getStaticPaths() {
     })
   );
   
+  // 個人サイト用に公開された記事のみフィルタリング
+  const publishedArticles = articles.filter(article => 
+    article.frontmatter['published-rioto3jp'] === true
+  );
+  
   // 静的パスを返す
-  return articles.map(article => {
+  return publishedArticles.map(article => {
     return {
       params: { slug: article.slug },
       props: {
@@ -75,13 +80,13 @@ const html = markdownToHtml(body, {
   embedOrigin: "https://embed.zenn.studio"
 });
 
-// Twitterの埋め込みを見つけてレスポンシブ対応
+// 以下のコードは以前と同じ（変更なし）
 function processTwitterEmbeds(html) {
   // Twitter埋め込みURLのパターン
-  const twitterEmbedPattern = /<a\s+[^>]*?href="https:\/\/twitter\.com\/[^"]*\/status\/[^"]*"[^>]*>.*?<\/a>/g;
+  const twitterEmbedPattern = /<a\\s+[^>]*?href=\"https:\\/\\/twitter\\.com\\/[^\"]*\\/status\\/[^\"]*\"[^>]*>.*?<\\/a>/g;
   
   // TwitterのURLパターン
-  const twitterUrlPattern = /https:\/\/twitter\.com\/([^\/]+)\/status\/([^\/\?"]+)/;
+  const twitterUrlPattern = /https:\\/\\/twitter\\.com\\/([^\\/]+)\\/status\\/([^\\/\\?\"]+)/;
   
   // レスポンシブ対応のブロックに置換
   return html.replace(twitterEmbedPattern, (match) => {
@@ -107,6 +112,7 @@ const processedHtml = processTwitterEmbeds(html);
 ---
 
 <MainLayout title={`${title} | Rioto3`} description={title}>
+  <!-- 以下のコンテンツは以前と同じ（変更なし） -->
   <article class="article-container">
     <!-- 記事ヘッダー部分 -->
     <div class="article-header pb-4 sm:pb-6 mb-4 sm:mb-6 border-b border-[#F7F6F2]">
@@ -163,7 +169,7 @@ const processedHtml = processTwitterEmbeds(html);
   </article>
 </MainLayout>
 
-<!-- Twitter埋め込み用のスクリプト、明示的に先に読み込み -->
+<!-- 以下のスクリプトは以前と同じ（変更なし） -->
 <script is:inline>
   // Twitter widgets JSを動的に読み込み
   window.twttrLoadPromise = new Promise((resolve) => {
@@ -181,7 +187,6 @@ const processedHtml = processTwitterEmbeds(html);
   });
 </script>
 
-<!-- Zenn埋め込み要素対応スクリプト -->
 <script is:inline src="https://embed.zenn.studio/js/listen-embed-event.js"></script>
 
 <script is:inline>

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -53,9 +53,9 @@ export async function getStaticPaths() {
     })
   );
   
-  // 個人サイト用に公開された記事のみフィルタリング
-  const publishedArticles = articles.filter(article => 
-    article.frontmatter['published-rioto3jp'] === true
+  // 個人サイト向けに公開された記事のみをフィルタリング
+  const publishedArticles = articles.filter(
+    article => article.frontmatter['published-rioto3jp'] === true
   );
   
   // 静的パスを返す
@@ -80,13 +80,13 @@ const html = markdownToHtml(body, {
   embedOrigin: "https://embed.zenn.studio"
 });
 
-// 以下のコードは以前と同じ（変更なし）
+// Twitterの埋め込みを見つけてレスポンシブ対応
 function processTwitterEmbeds(html) {
   // Twitter埋め込みURLのパターン
-  const twitterEmbedPattern = /<a\\s+[^>]*?href=\"https:\\/\\/twitter\\.com\\/[^\"]*\\/status\\/[^\"]*\"[^>]*>.*?<\\/a>/g;
+  const twitterEmbedPattern = /<a\s+[^>]*?href="https:\/\/twitter\.com\/[^"]*\/status\/[^"]*"[^>]*>.*?<\/a>/g;
   
   // TwitterのURLパターン
-  const twitterUrlPattern = /https:\\/\\/twitter\\.com\\/([^\\/]+)\\/status\\/([^\\/\\?\"]+)/;
+  const twitterUrlPattern = /https:\/\/twitter\.com\/([^\/]+)\/status\/([^\/\?"]+)/;
   
   // レスポンシブ対応のブロックに置換
   return html.replace(twitterEmbedPattern, (match) => {
@@ -112,7 +112,6 @@ const processedHtml = processTwitterEmbeds(html);
 ---
 
 <MainLayout title={`${title} | Rioto3`} description={title}>
-  <!-- 以下のコンテンツは以前と同じ（変更なし） -->
   <article class="article-container">
     <!-- 記事ヘッダー部分 -->
     <div class="article-header pb-4 sm:pb-6 mb-4 sm:mb-6 border-b border-[#F7F6F2]">
@@ -169,7 +168,7 @@ const processedHtml = processTwitterEmbeds(html);
   </article>
 </MainLayout>
 
-<!-- 以下のスクリプトは以前と同じ（変更なし） -->
+<!-- Twitter埋め込み用のスクリプト、明示的に先に読み込み -->
 <script is:inline>
   // Twitter widgets JSを動的に読み込み
   window.twttrLoadPromise = new Promise((resolve) => {
@@ -187,6 +186,7 @@ const processedHtml = processTwitterEmbeds(html);
   });
 </script>
 
+<!-- Zenn埋め込み要素対応スクリプト -->
 <script is:inline src="https://embed.zenn.studio/js/listen-embed-event.js"></script>
 
 <script is:inline>

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -50,9 +50,9 @@ const articleEntries = await Promise.all(
   })
 );
 
-// 公開済みの記事のみフィルタリング
+// 個人サイト用に公開された記事のみフィルタリング
 const publishedArticles = articleEntries
-  .filter(article => article.frontmatter.published !== false)
+  .filter(article => article.frontmatter['published-rioto3jp'] === true)
   .sort((a, b) => 
     new Date(b.frontmatter.date || 0) - new Date(a.frontmatter.date || 0)
   );

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,9 +53,9 @@ const articleEntries = await Promise.all(
   })
 );
 
-// 公開済みの記事のみフィルタリング
+// 個人サイト用に公開された記事のみフィルタリング
 const publishedArticles = articleEntries
-  .filter(article => article.frontmatter.published !== false)
+  .filter(article => article.frontmatter['published-rioto3jp'] === true)
   .sort((a, b) => 
     new Date(b.frontmatter.date || 0) - new Date(a.frontmatter.date || 0)
   )

--- a/src/utils/contentFetcher.ts
+++ b/src/utils/contentFetcher.ts
@@ -8,6 +8,8 @@ export interface ArticleContent {
   frontmatter: {
     title: string;
     date: string;
+    published?: boolean;
+    'published-rioto3jp'?: boolean;
     [key: string]: any;
   };
 }
@@ -45,6 +47,8 @@ export async function fetchLocalMarkdownFiles(
       frontmatter: {
         title: data.title || path.basename(file, '.md'),
         date: data.date || new Date().toISOString(),
+        published: data.published || false,
+        'published-rioto3jp': data['published-rioto3jp'] || false,
         ...data
       }
     };


### PR DESCRIPTION
## Changes
- Add `published-rioto3jp` flag to `ArticleContent` interface
- Update filtering logic in:
  - `index.astro`
  - `[slug].astro`
  - Top page routing

## Details
- New flag allows independent publishing control
- Default value is `false`
- Only articles explicitly set to `true` will be published

## Checklist
- [x] Update TypeScript interfaces
- [x] Modify `getStaticPaths`
- [x] Update article filtering
- [x] Test various publishing scenarios

Closes #31